### PR TITLE
Docker build patchups

### DIFF
--- a/.github/linters/.hadolint.yaml
+++ b/.github/linters/.hadolint.yaml
@@ -1,3 +1,4 @@
-# Don't know how to keep this rule enabled while staying sane re: chrome's apt pkg
+# Don't know how to keep this DL3008 rule enabled while staying sane re: chrome's apt pkg
 # probably need to get it installed through other means?
-ignored: [DL3008]
+# DL3029: also needed for builds to work with chrome apt for some reason?
+ignored: [DL3008, DL3029]

--- a/.github/workflows/image_build_and_publish.yml
+++ b/.github/workflows/image_build_and_publish.yml
@@ -1,6 +1,8 @@
 name: Build and Publish Images to GCR
 
 on:
+  pull_request:
+    branches: [main]
   workflow_call:
     outputs:
       image_name:

--- a/.github/workflows/image_build_and_publish.yml
+++ b/.github/workflows/image_build_and_publish.yml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Authenticate to Google Cloud
+        if: github.event_name != 'pull_request'
         uses: google-github-actions/auth@v1
         id: auth
         with:
@@ -46,6 +47,7 @@ jobs:
           token_format: access_token
 
       - name: Login to GCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: gcr.io

--- a/.github/workflows/image_build_and_publish.yml
+++ b/.github/workflows/image_build_and_publish.yml
@@ -73,7 +73,7 @@ jobs:
           context: .
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          push: true
+          push: github.event_name != 'pull_request'
           tags: ${{ steps.meta.outputs.tags }}
           target: ${{ matrix.service }}
           # Using native GitHub action caching as shown here:

--- a/.github/workflows/image_build_and_publish.yml
+++ b/.github/workflows/image_build_and_publish.yml
@@ -77,7 +77,7 @@ jobs:
           context: .
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
-          push: github.event_name != 'pull_request'
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           target: ${{ matrix.service }}
           # Using native GitHub action caching as shown here:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN mkdir -m 0755 -p /etc/apt/keyrings/ \
         google-chrome-stable \
         build-essential=12.9 \
         libpython3-dev \
-        swig=4.0.2-1 \
         fonts-liberation=1:1.07.4-11 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -29,6 +28,7 @@ RUN pip install \
         --no-cache-dir \
         --trusted-host pypi.python.org \
         --requirement requirements.txt \
+        swig \
         google-python-cloud-debugger==2.18
 
 COPY ./config/ ./config

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -m 0755 -p /etc/apt/keyrings/ \
     && apt-get install --no-install-recommends -y \
         google-chrome-stable \
         build-essential=12.9 \
-        python3-dev=3.9.2-3 \
+        libpython3-dev \
         swig=4.0.2-1 \
         fonts-liberation=1:1.07.4-11 \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ ENV PYTHONUNBUFFERED True
 WORKDIR /app
 
 # Various pre-requisites for getting m2crypto install (which in turn is used by passkit)
-RUN mkdir -m 0755 -p /etc/apt/keyrings/ \
+RUN mkdir --parents /etc/apt/keyrings/ \
+  && chmod 0755 /etc/apt/keyrings/ \
   && bash -c 'set -o pipefail && wget -O- https://dl.google.com/linux/linux_signing_key.pub \
     | gpg --dearmor > /etc/apt/keyrings/google-chrome.gpg \
     && chmod 644 /etc/apt/keyrings/google-chrome.gpg' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ ENV PYTHONUNBUFFERED True
 WORKDIR /app
 
 # Various pre-requisites for getting m2crypto install (which in turn is used by passkit)
-RUN bash -c 'set -o pipefail && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -' \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+RUN mkdir -m 0755 -p /etc/apt/keyrings/ \
+  && bash -c 'set -o pipefail && wget -O- https://dl.google.com/linux/linux_signing_key.pub \
+    | gpg --dearmor > /etc/apt/keyrings/google-chrome.gpg \
+    && chmod 644 /etc/apt/keyrings/google-chrome.gpg' \
+    && sh -c 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list' \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
         google-chrome-stable \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9 AS worker
+FROM --platform=linux/amd64 python:3.9 AS worker
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True
@@ -34,7 +34,7 @@ COPY ./*.py ./
 
 CMD ["gunicorn", "--bind=:8080", "--workers=1", "--threads=8", "--timeout=0", "--log-config=config/gunicron_logging.ini", "--log-file=-", "wsgi:create_worker_app()"]
 
-FROM python:3.9-slim AS website
+FROM --platform=linux/amd64 python:3.9 AS website
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True


### PR DESCRIPTION
Upstream drift in various OS versions and such has left us with non-functional docker builds 😢:  https://github.com/los-verdes/digital-membership/actions/runs/7938077248/job/21676384696#step:7:336

Would be nice to get more upstream things pinned (and get us to newer Python versions + trim down some Python package excess) but another day...