### PR TITLE
Toggle on Slack User ETL & Toggle Off "Customers" ETL

### DIFF
--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -18,6 +18,7 @@ locals {
     sync_subscriptions_etl = {
       description = "Regularly recurring Squarespace order into membership database ETL task"
       schedule    = "0 * * * *"
+      paused      = true
       data = {
         type = "sync_subscriptions_etl",
       }

--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -15,6 +15,14 @@ locals {
         type = "sync_customers_etl",
       }
     }
+    sync_subscriptions_etl = {
+      description = "Regularly recurring Squarespace order into membership database ETL task"
+      schedule    = "0 * * * *"
+      data = {
+        type = "sync_subscriptions_etl",
+      }
+
+    }
   }
 }
 
@@ -28,18 +36,5 @@ resource "google_cloud_scheduler_job" "worker" {
   pubsub_target {
     topic_name = google_pubsub_topic.digital_membership.id
     data       = base64encode(jsonencode(each.value.data))
-  }
-}
-
-resource "google_cloud_scheduler_job" "sync_subscriptions_etl" {
-  name        = "sync-subscriptions-etl"
-  description = "Regularly recurring Squarespace order into membership database ETL task"
-  schedule    = "0 * * * *"
-
-  pubsub_target {
-    topic_name = google_pubsub_topic.digital_membership.id
-    data = base64encode(jsonencode({
-      type = "sync_subscriptions_etl",
-    }))
   }
 }

--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -3,7 +3,6 @@ locals {
     run_slack_members_etl = {
       description = "Sync Slack member / user data into local digital membership database"
       schedule    = "0 */6 * * *"
-      paused      = true
       data = {
         type = "run_slack_members_etl",
       }
@@ -11,6 +10,7 @@ locals {
     sync_customers_etl = {
       description = "Sync E-commerce customer / user data into local digital membership database"
       schedule    = "30 * * * *"
+      paused      = true
       data = {
         type = "sync_customers_etl",
       }
@@ -18,7 +18,6 @@ locals {
     sync_subscriptions_etl = {
       description = "Regularly recurring Squarespace order into membership database ETL task"
       schedule    = "0 * * * *"
-      paused      = true
       data = {
         type = "sync_subscriptions_etl",
       }


### PR DESCRIPTION
I forget exactly why I added this customer ETL. I think it was intended to merge membership orders across users that mapped to the same member but were under different email addresses. At this point, I'm not confident that the logic involved is sound and I'm certain that it breaks our worker service when there are multiple users, for the same member, but differing emails. So I'm proposing we leave it toggled off for the time being. 

Slack users ETL has been cleared of any wrongdoing for now 😄 