### PR TITLE
Revert "`s/gcr.io/pkg.dev/g`"

### DIFF
--- a/.github/workflows/image_build_and_publish.yml
+++ b/.github/workflows/image_build_and_publish.yml
@@ -50,7 +50,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          registry: pkg.dev
+          registry: gcr.io
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,15 +68,15 @@ jobs:
           just tf init
           just tf plan
         env:
-          TF_VAR_website_image: "pkg.dev/lv-digital-membership/website:sha-${{ needs.build_images.outputs.short_sha_tag }}"
-          TF_VAR_worker_image: "pkg.dev/lv-digital-membership/worker:sha-${{ needs.build_images.outputs.short_sha_tag }}"
+          TF_VAR_website_image: "gcr.io/lv-digital-membership/website:sha-${{ needs.build_images.outputs.short_sha_tag }}"
+          TF_VAR_worker_image: "gcr.io/lv-digital-membership/worker:sha-${{ needs.build_images.outputs.short_sha_tag }}"
           TF_VAR_management_sql_user_password: ${{ secrets.management_sql_user_password }}
 
       - name: Apply
         run: just tf apply -auto-approve
         env:
-          TF_VAR_website_image: "pkg.dev/lv-digital-membership/website:sha-${{ needs.build_images.outputs.short_sha_tag }}"
-          TF_VAR_worker_image: "pkg.dev/lv-digital-membership/worker:sha-${{ needs.build_images.outputs.short_sha_tag }}"
+          TF_VAR_website_image: "gcr.io/lv-digital-membership/website:sha-${{ needs.build_images.outputs.short_sha_tag }}"
+          TF_VAR_worker_image: "gcr.io/lv-digital-membership/worker:sha-${{ needs.build_images.outputs.short_sha_tag }}"
           TF_VAR_management_sql_user_password: ${{ secrets.management_sql_user_password }}
 
   upload-statics-to-gcs:

--- a/cloudbuild-statics.yaml
+++ b/cloudbuild-statics.yaml
@@ -3,13 +3,13 @@ substitutions:
   _BUCKET_ID: "statics-gcs-bucket"
 
 steps:
-  - name: "pkg.dev/$PROJECT_ID/website:${_IMAGE_TAG}"
+  - name: "gcr.io/$PROJECT_ID/website:${_IMAGE_TAG}"
     entrypoint: "flask"
     args:
       - assets
       - build
 
-  - name: "pkg.dev/cloud-builders/gsutil"
+  - name: "gcr.io/cloud-builders/gsutil"
     args:
       - "-m"
       - "cp"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,27 +4,27 @@ substitutions:
 
 steps:
   # Download image to cache from
-  - name: "pkg.dev/cloud-builders/docker"
+  - name: "gcr.io/cloud-builders/docker"
     entrypoint: "bash"
     args:
       - "-c"
-      - "docker pull pkg.dev/$PROJECT_ID/worker:latest || exit 0"
+      - "docker pull gcr.io/$PROJECT_ID/worker:latest || exit 0"
 
   # Docker Build
-  - name: "pkg.dev/cloud-builders/docker"
+  - name: "gcr.io/cloud-builders/docker"
     args:
       - "build"
-      - "--cache-from=pkg.dev/$PROJECT_ID/${_BUILD_TARGET}:latest"
+      - "--cache-from=gcr.io/$PROJECT_ID/${_BUILD_TARGET}:latest"
       - "--target=${_BUILD_TARGET}"
-      - "--tag=pkg.dev/$PROJECT_ID/${_BUILD_TARGET}:${_IMAGE_TAG}"
+      - "--tag=gcr.io/$PROJECT_ID/${_BUILD_TARGET}:${_IMAGE_TAG}"
       - "."
 
-  - name: "pkg.dev/cloud-builders/docker"
+  - name: "gcr.io/cloud-builders/docker"
     args:
       - "tag"
-      - "pkg.dev/$PROJECT_ID/${_BUILD_TARGET}:${_IMAGE_TAG}"
-      - "pkg.dev/$PROJECT_ID/${_BUILD_TARGET}:latest"
+      - "gcr.io/$PROJECT_ID/${_BUILD_TARGET}:${_IMAGE_TAG}"
+      - "gcr.io/$PROJECT_ID/${_BUILD_TARGET}:latest"
 
 images:
-  - "pkg.dev/$PROJECT_ID/${_BUILD_TARGET}:${_IMAGE_TAG}"
-  - "pkg.dev/$PROJECT_ID/${_BUILD_TARGET}:latest"
+  - "gcr.io/$PROJECT_ID/${_BUILD_TARGET}:${_IMAGE_TAG}"
+  - "gcr.io/$PROJECT_ID/${_BUILD_TARGET}:latest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
 
   member_card:
     build: .
-    # image: "pkg.dev/lv-digital-membership/member-card:latest"
+    # image: "gcr.io/lv-digital-membership/member-card:latest"
     restart: always
     command: flask run
     links:

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ db_tf_subdir   := "./terraform/database"
 bootstrap_tf_subdir   := "./terraform/bootstrap"
 tfvars_file    := "lv-digital-membership.tfvars"
 
-gcr_repo := "pkg.dev/lv-digital-membership"
+gcr_repo := "gcr.io/lv-digital-membership"
 image_tag := `git describe --tags --dirty --long --always`
 website_image_name := "website"
 website_gcr_image_name := gcr_repo + "/" + website_image_name

--- a/lv-digital-membership.tfvars
+++ b/lv-digital-membership.tfvars
@@ -10,5 +10,5 @@ gcp_region = "us-central1"
 github_repo = "los-verdes/digital-membership"
 
 membership_squarespace_sku = "SQ3671268"
-# cloud_run_container_image = "pkg.dev/lv-digital-membership/member-card"
+# cloud_run_container_image = "gcr.io/lv-digital-membership/member-card"
 app_log_level = "DEBUG"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,10 +42,10 @@ variable "management_sql_user_password" {
 
 variable "website_image" {
   type    = string
-  default = "pkg.dev/lv-digital-membership/website:latest"
+  default = "gcr.io/lv-digital-membership/website:latest"
 }
 
 variable "worker_image" {
   type    = string
-  default = "pkg.dev/lv-digital-membership/worker:latest"
+  default = "gcr.io/lv-digital-membership/worker:latest"
 }


### PR DESCRIPTION
This reverts commit da0211ce7dd193dc694ff342b759e8ec30dbc4be. Turns out we can do an [automation migration deal instead](https://cloud.google.com/artifact-registry/docs/transition/auto-migrate-gcr-ar)!